### PR TITLE
Wording fixes (remove ES7 + function decorator references)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Fitted
 
 [![Build Status](https://travis-ci.org/JBlaak/Fitted.svg?branch=master)](https://travis-ci.org/JBlaak/Fitted)
 
-Use ES7 decorators to execute HTTP requests and manage processing of responses, an easy and readable way of managing
+Use ECMAScript decorators ([currently a Stage 2 proposal](https://github.com/tc39/proposals)) to
+execute HTTP requests and manage processing of responses, an easy and readable way of managing
 how data flows through the networking layer of your application.
 
 Example

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ how data flows through the networking layer of your application.
 Example
 ----
 
-Two main parts, the function decorators which will actually do the request, and the class decorators
+Two main parts, the method decorators which will actually do the request, and the class decorators
 which will allow you to handle the way responses from the server are transformed and handled.
 
 The simplest example is just a fetch of data from a JSON endpoint:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fitted",
   "version": "0.1.7",
-  "description": "Simplifying http requests using ES7 decorators",
+  "description": "Simplifying http requests using ES decorators",
   "main": "build/fitted.js",
   "scripts": {
     "prepublish": "npm run build",


### PR DESCRIPTION
Hey,

Decorators actually [didn't make it into ES7](http://www.2ality.com/2016/01/ecmascript-2016.html) (and [they're still a Stage 2 proposal](https://github.com/tc39/proposals) so I'd be a bit surprised if they made it into ES8 at this point)... I've updated the wording in `README.md` and `package.json` to better reflect their status.

Also changed "function decorators" ([which are actually a separate Stage 0 proposal](https://github.com/tc39/proposals/blob/master/stage-0-proposals.md)) to "method decorators" in the README; feel free to squash the commits if you'd prefer.

Thanks for open-sourcing your work! =)